### PR TITLE
Make image url secure

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -102,7 +102,7 @@ class Thumbnail extends PureComponent {
       ...props,
     } = this.props;
 
-    const imageURL = `http://img.youtube.com/vi/${videoId}/${this.getType()}.jpg`;
+    const imageURL = `https://img.youtube.com/vi/${videoId}/${this.getType()}.jpg`;
 
     return (
       <TouchableOpacity


### PR DESCRIPTION
on iOS the url has to be `https` otherwise it won't load.