### PR TITLE
Babel required by RN 0.56.0 doens't like this trailing comma

### DIFF
--- a/src/components/thumbnail.js
+++ b/src/components/thumbnail.js
@@ -89,7 +89,7 @@ export default class Thumbnail extends PureComponent {
       iconStyle,
       children,
       showPlayIcon,
-      ...props,
+      ...props
     } = this.props;
 
     const imageURL = `https://img.youtube.com/vi/${videoId}/${this.getType()}.jpg`;


### PR DESCRIPTION
When upgrading babel to the version recommended by RN 0.56.0, this project no longer compiles because of this trailing comma.  I've removed it here.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/lucasbento/react-native-thumbnail-video/17)
<!-- Reviewable:end -->
